### PR TITLE
Add cyberpunk material options

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,12 +158,20 @@ function init(){
     createLargeEmissiveScreen();
     createRain();
 
-    const extraBuilding = createSimpleBuilding();
+    const extraBuilding = createSimpleBuilding({
+        color: 0x222233,
+        roughness: 0.85,
+        metalness: 0.6
+    });
     extraBuilding.position.set(0, CONFIG.camera.BASE_HEIGHT / 2, -400);
     scene.add(extraBuilding);
     buildings.push(extraBuilding);
 
-    const demoCar = createSimpleCar();
+    const demoCar = createSimpleCar({
+        bodyColor: 0x222222,
+        roughness: 0.6,
+        metalness: 0.7
+    });
     demoCar.position.set(0, 5, -50);
     scene.add(demoCar);
 

--- a/src/buildings.js
+++ b/src/buildings.js
@@ -1,11 +1,21 @@
 import * as THREE from 'three';
 
-export function createSimpleBuilding() {
+const CYBERPUNK_BUILDING_MATERIALS = [
+    { color: 0x202025, roughness: 0.95, metalness: 0.15 }, // Dark concrete
+    { color: 0x25282a, roughness: 0.7,  metalness: 0.8  }, // Grimy metal
+    { color: 0x181818, roughness: 0.4,  metalness: 0.5  }, // Coated panel
+    { color: 0x202228, roughness: 0.85, metalness: 0.7  }  // Heavy duty structure
+];
+
+export function createSimpleBuilding(options = {}) {
+    const preset = options.preset ??
+        CYBERPUNK_BUILDING_MATERIALS[
+            Math.floor(Math.random() * CYBERPUNK_BUILDING_MATERIALS.length)
+        ];
     const material = new THREE.MeshStandardMaterial({
-        // Use a neutral grey so demo buildings are not brightly colored
-        color: 0x666666,
-        roughness: 0.8,
-        metalness: 0.2
+        color: options.color ?? preset.color,
+        roughness: options.roughness ?? preset.roughness,
+        metalness: options.metalness ?? preset.metalness
     });
     const mesh = new THREE.Mesh(new THREE.BoxGeometry(40, 150, 40), material);
     mesh.castShadow = false;

--- a/src/cars.js
+++ b/src/cars.js
@@ -1,9 +1,21 @@
 import * as THREE from 'three';
 
-export function createSimpleCar() {
+const CYBERPUNK_CAR_MATERIALS = [
+    { color: 0x111111, roughness: 0.9, metalness: 0.2 }, // Matte black
+    { color: 0x333333, roughness: 0.6, metalness: 0.8 }, // Gunmetal
+    { color: 0x222222, roughness: 0.7, metalness: 0.6 }, // Dark grey
+    { color: 0x2b2b35, roughness: 0.5, metalness: 0.7 }  // Bluish steel
+];
+
+export function createSimpleCar(options = {}) {
     const group = new THREE.Group();
-    // Car body should be grey instead of brightly coloured
-    const bodyMat = new THREE.MeshStandardMaterial({ color: 0x666666, metalness: 0.3, roughness: 0.6 });
+    const preset = options.preset ??
+        CYBERPUNK_CAR_MATERIALS[Math.floor(Math.random() * CYBERPUNK_CAR_MATERIALS.length)];
+    const bodyMat = new THREE.MeshStandardMaterial({
+        color: options.bodyColor ?? preset.color,
+        roughness: options.roughness ?? preset.roughness,
+        metalness: options.metalness ?? preset.metalness
+    });
     const body = new THREE.Mesh(new THREE.BoxGeometry(16, 4, 8), bodyMat);
     body.position.y = 2;
     group.add(body);


### PR DESCRIPTION
## Summary
- add new presets for buildings and cars
- allow `createSimpleBuilding` and `createSimpleCar` to accept material options
- show cyberpunk options when spawning the demo building and car

## Testing
- `node -v`