### PR TITLE
Reduce scene load and document GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@ This project renders a Three.js scene with a drone flying through a neon citysca
 ## Running the project
 
 Modern browsers require ES modules to be served over HTTP. If you open `index.html` directly with the `file://` protocol, the import map in the HTML file will not resolve the modules and the page will fail to load. To view the project correctly, serve the directory through a local web server and then visit the page via `http://localhost`.
+The scene pulls Three.js modules from the CDN at [unpkg.com](https://unpkg.com/), so an active internet connection is required. If you need to run the project completely offline, download those modules and update the import paths accordingly.
+
+### GitHub Pages
+
+You can deploy the project to GitHub Pages and access it from a URL such as
+`https://USERNAME.github.io/cyberpunk_city/`. The site is purely static, so no
+extra build step is required. Be aware that the 3D scene is resource intensive;
+older mobile devices or browsers without WebGL support may fail to render it.
+If the page performs poorly, reduce values in the `CONFIG` object near the top of
+`index.html` (for example, `NUM_BUILDINGS` or `RAIN_COUNT`).
 
 ### Using Python
 

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@ import { createSimpleCar } from "./src/cars.js";
 /* ---------- CONFIG ---------- */
 const CONFIG={
     city:{
-        NUM_BUILDINGS:300,
+        NUM_BUILDINGS:150,
         CITY_RADIUS:700,
         CORRIDOR_WIDTH:120,
         BUILDING_MIN_Y_OFFSET: 80,
@@ -54,7 +54,7 @@ const CONFIG={
         DISTRICT_LENGTH: 800
     },
     trafficZ:{ // Renamed from traffic to trafficZ for clarity
-        NUM_CARS:100,
+        NUM_CARS:60,
         SPEED_MIN:30,
         SPEED_MAX:90,
         TRUCK_PROBABILITY: 0.15,
@@ -65,7 +65,7 @@ const CONFIG={
     },
     trafficX: { // New: Configuration for X-axis traffic
         NUM_JUNCTIONS: 3,
-        CARS_PER_JUNCTION: 10,
+        CARS_PER_JUNCTION: 6,
         JUNCTION_Z_OFFSETS: [-200, -450, -700], // Z distance from camera for each junction layer
         JUNCTION_X_TRAVEL_WIDTH: 1000,      // How far cars travel left/right before wrapping
         JUNCTION_Z_DEPTH_VARIATION: 30,     // Small random Z spread within a junction layer
@@ -93,7 +93,7 @@ const CONFIG={
     },
     effects:{
         BLOOM_STRENGTH: 2.0,
-        RAIN_COUNT: 800,
+        RAIN_COUNT: 400,
         RAIN_SPEED:330,
         RAIN_PARTICLE_SIZE: 0.08,
         RAIN_CULL_DISTANCE_Z: 20,


### PR DESCRIPTION
## Summary
- lighten the scene config to help the page load on GitHub Pages
- add instructions for deploying on GitHub Pages and mention performance tuning

## Testing
- `node -v`
