### PR TITLE
Reduce scene complexity and document GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,22 @@ This project renders a Three.js scene with a drone flying through a neon citysca
 ## Running the project
 
 Modern browsers require ES modules to be served over HTTP. If you open `index.html` directly with the `file://` protocol, the import map in the HTML file will not resolve the modules and the page will fail to load. To view the project correctly, serve the directory through a local web server and then visit the page via `http://localhost`.
+The scene pulls Three.js modules from the CDN at [unpkg.com](https://unpkg.com/), so an active internet connection is required. If you need to run the project completely offline, download those modules and update the import paths accordingly.
+
+### GitHub Pages
+
+You can host this project on GitHub Pages. Commit the files to a repository and enable Pages in the repository settings, using the `main` branch and `/` root. It may take a few minutes for the page to become available at `https://<username>.github.io/<repo>/`.
+
+If the scene fails to load due to memory constraints, lower the object counts defined near the top of `index.html`. The defaults are tuned for lightweight hosting:
+
+```
+city.NUM_BUILDINGS = 150
+trafficZ.NUM_CARS  = 50
+trafficX.CARS_PER_JUNCTION = 5
+effects.RAIN_COUNT = 400
+```
+
+Decrease these values further if you see "Out of Memory" errors.
 
 ### Using Python
 

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@ import { createSimpleCar } from "./src/cars.js";
 /* ---------- CONFIG ---------- */
 const CONFIG={
     city:{
-        NUM_BUILDINGS:300,
+        NUM_BUILDINGS:150,
         CITY_RADIUS:700,
         CORRIDOR_WIDTH:120,
         BUILDING_MIN_Y_OFFSET: 80,
@@ -54,7 +54,7 @@ const CONFIG={
         DISTRICT_LENGTH: 800
     },
     trafficZ:{ // Renamed from traffic to trafficZ for clarity
-        NUM_CARS:100,
+        NUM_CARS:50,
         SPEED_MIN:30,
         SPEED_MAX:90,
         TRUCK_PROBABILITY: 0.15,
@@ -65,7 +65,7 @@ const CONFIG={
     },
     trafficX: { // New: Configuration for X-axis traffic
         NUM_JUNCTIONS: 3,
-        CARS_PER_JUNCTION: 10,
+        CARS_PER_JUNCTION: 5,
         JUNCTION_Z_OFFSETS: [-200, -450, -700], // Z distance from camera for each junction layer
         JUNCTION_X_TRAVEL_WIDTH: 1000,      // How far cars travel left/right before wrapping
         JUNCTION_Z_DEPTH_VARIATION: 30,     // Small random Z spread within a junction layer
@@ -93,7 +93,7 @@ const CONFIG={
     },
     effects:{
         BLOOM_STRENGTH: 2.0,
-        RAIN_COUNT: 800,
+        RAIN_COUNT: 400,
         RAIN_SPEED:330,
         RAIN_PARTICLE_SIZE: 0.08,
         RAIN_CULL_DISTANCE_Z: 20,


### PR DESCRIPTION
## Summary
- document GitHub Pages hosting and how to lower object counts
- reduce default counts for buildings, cars, and rain particles

## Testing
- `node -v`
