### PR TITLE
Add office lights to simple buildings

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,7 +161,8 @@ function init(){
     const extraBuilding = createSimpleBuilding({
         color: 0x222233,
         roughness: 0.85,
-        metalness: 0.6
+        metalness: 0.6,
+        officeLights: true
     });
     extraBuilding.position.set(0, CONFIG.camera.BASE_HEIGHT / 2, -400);
     scene.add(extraBuilding);

--- a/src/buildings.js
+++ b/src/buildings.js
@@ -4,7 +4,9 @@ const CYBERPUNK_BUILDING_MATERIALS = [
     { color: 0x202025, roughness: 0.95, metalness: 0.15 }, // Dark concrete
     { color: 0x25282a, roughness: 0.7,  metalness: 0.8  }, // Grimy metal
     { color: 0x181818, roughness: 0.4,  metalness: 0.5  }, // Coated panel
-    { color: 0x202228, roughness: 0.85, metalness: 0.7  }  // Heavy duty structure
+    { color: 0x202228, roughness: 0.85, metalness: 0.7  }, // Heavy duty structure
+    { color: 0x1a1a1a, roughness: 0.5, metalness: 0.3  }, // Dark stone
+    { color: 0x2a2e32, roughness: 0.4, metalness: 0.9  }  // Tinted glass
 ];
 
 export function createSimpleBuilding(options = {}) {
@@ -12,6 +14,9 @@ export function createSimpleBuilding(options = {}) {
         CYBERPUNK_BUILDING_MATERIALS[
             Math.floor(Math.random() * CYBERPUNK_BUILDING_MATERIALS.length)
         ];
+
+    const group = new THREE.Group();
+
     const material = new THREE.MeshStandardMaterial({
         color: options.color ?? preset.color,
         roughness: options.roughness ?? preset.roughness,
@@ -20,5 +25,57 @@ export function createSimpleBuilding(options = {}) {
     const mesh = new THREE.Mesh(new THREE.BoxGeometry(40, 150, 40), material);
     mesh.castShadow = false;
     mesh.receiveShadow = false;
-    return mesh;
+    group.add(mesh);
+
+    if (options.officeLights) {
+        addOfficeWindows(group, 40, 150, 40);
+    }
+
+    return group;
+}
+
+function addOfficeWindows(target, width, height, depth) {
+    const litMat = new THREE.MeshBasicMaterial({
+        color: 0xffeeaa,
+        toneMapped: false
+    });
+    const darkMat = new THREE.MeshBasicMaterial({
+        color: 0x000000,
+        toneMapped: false
+    });
+    const windowGeo = new THREE.PlaneGeometry(2, 1.5);
+    const spacingX = 5;
+    const spacingY = 4;
+    const margin = 5;
+    const cols = Math.floor((width - margin * 2) / spacingX);
+    const rows = Math.floor((height - margin * 2) / spacingY);
+
+    for (let side = 0; side < 4; side++) {
+        for (let i = 0; i < cols; i++) {
+            for (let j = 0; j < rows; j++) {
+                const mat = Math.random() < 0.6 ? litMat : darkMat;
+                const win = new THREE.Mesh(windowGeo, mat);
+                const x = -width/2 + margin + i * spacingX;
+                const y = -height/2 + margin + j * spacingY;
+                switch (side) {
+                    case 0: // front
+                        win.position.set(x, y, depth/2 + 0.01);
+                        break;
+                    case 1: // back
+                        win.position.set(x, y, -depth/2 - 0.01);
+                        win.rotation.y = Math.PI;
+                        break;
+                    case 2: // left
+                        win.position.set(-width/2 - 0.01, y, x);
+                        win.rotation.y = -Math.PI/2;
+                        break;
+                    case 3: // right
+                        win.position.set(width/2 + 0.01, y, x);
+                        win.rotation.y = Math.PI/2;
+                        break;
+                }
+                target.add(win);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- expand the building material presets
- add optional office windows with emissive lighting in `createSimpleBuilding`
- enable office lights for the demo building in `index.html`

## Testing
- `git status --short`