### PR TITLE
Implement flicker toggle and sign adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ The first time you run this command, install dependencies with `npm install`.
 
 All code is contained in `index.html` and the `src/` directory. No build step is required.
 
+## Configuration
+
+The `CONFIG` object in `index.html` exposes various options. To disable the neon flickering effect, set:
+
+```javascript
+CONFIG.misc.ENABLE_FLICKER = false;
+```
+
+Reload the page after editing the file to see the change.
+
 ## Running on GitHub Pages
 
 The project works when hosted from any subdirectory, so you can serve it via GitHub Pages. Publish the repository (or a `gh-pages` branch) using GitHub Pages and visit:

--- a/index.html
+++ b/index.html
@@ -107,7 +107,8 @@ const CONFIG={
         SPAWN_PADDING:300,
         NEON_COLORS:[
             0xff4400,0x00aaff,0xffdd33,0xff2222,0xcc00ff,0x00dd88,0xeeeeff,
-        ]
+        ],
+        ENABLE_FLICKER:true
     }
 };
 
@@ -359,7 +360,7 @@ function addNeons(parent,w,d,h_geom){
         });
         const sign=new THREE.Mesh(new THREE.PlaneGeometry(nW_sign,nH_sign), signMaterial);
         sign.position.y=(Math.random()-0.5)*(h_geom*0.85);
-        const off=0.11;
+        const off=0.01;
         switch(face){case 0:sign.position.z=d/2+off;break;case 1:sign.position.z=-d/2-off;sign.rotation.y=Math.PI;break;case 2:sign.position.x=w/2+off;sign.rotation.y=Math.PI/2;break;case 3:sign.position.x=-w/2-off;sign.rotation.y=-Math.PI/2;break;}
         parent.add(sign);
     }
@@ -813,18 +814,20 @@ function animate(){
 
 
     // Neon flickering
-    [...buildings,...billboards].forEach(obj=>{
-        if (obj.userData && obj.userData.baseSegment) {
-             obj.userData.baseSegment.children?.forEach(n=>{
-                if(n.material && n.material.opacity !== undefined){
-                    if (Math.random() < 0.008) n.material.opacity = Math.random() * 0.3 + 0.1;
-                    else if (Math.random() < 0.012) n.material.opacity = Math.random() * 0.5 + 0.5;
-                }
-            });
-        } else if (obj.material && obj.material.opacity !== undefined && obj.isMesh) {
-            if(Math.random()<0.01) obj.material.opacity = 0.15 + Math.random()*0.3;
-        }
-    });
+    if(CONFIG.misc.ENABLE_FLICKER){
+        [...buildings,...billboards].forEach(obj=>{
+            if (obj.userData && obj.userData.baseSegment) {
+                 obj.userData.baseSegment.children?.forEach(n=>{
+                    if(n.material && n.material.opacity !== undefined){
+                        if (Math.random() < 0.008) n.material.opacity = Math.random() * 0.3 + 0.1;
+                        else if (Math.random() < 0.012) n.material.opacity = Math.random() * 0.5 + 0.5;
+                    }
+                });
+            } else if (obj.material && obj.material.opacity !== undefined && obj.isMesh) {
+                if(Math.random()<0.01) obj.material.opacity = 0.15 + Math.random()*0.3;
+            }
+        });
+    }
 
     // Rain animation
     if(rain && CONFIG.effects.RAIN_FADE_PERIOD > 0){


### PR DESCRIPTION
## Summary
- allow disabling neon flickering via `CONFIG.misc.ENABLE_FLICKER`
- reduce neon sign offset so signs sit closer to buildings
- document the new configuration flag in the README

## Testing
- `npm test` *(fails: Missing script `test`)*