### PR TITLE
Reduce window z-fighting

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,7 +126,7 @@ function init(){
     scene.background=new THREE.Color(0x060812);
     scene.fog=new THREE.FogExp2(0x101520, 0.0012);
 
-    camera=new THREE.PerspectiveCamera(75,window.innerWidth/window.innerHeight,0.1,CONFIG.misc.VISIBLE_DEPTH+CONFIG.misc.SPAWN_PADDING+400);
+    camera=new THREE.PerspectiveCamera(75,window.innerWidth/window.innerHeight,1,CONFIG.misc.VISIBLE_DEPTH+CONFIG.misc.SPAWN_PADDING+400);
     camera.position.set(0,CONFIG.camera.BASE_HEIGHT,0);
     currentTrackedCarX = camera.position.x;
 

--- a/src/buildings.js
+++ b/src/buildings.js
@@ -69,18 +69,18 @@ export function addOfficeWindows(target, width, height, depth) {
                 obj.rotation.set(0,0,0);
                 switch (side) {
                     case 0: // front
-                        obj.position.set(x, y, depth/2 + 0.01);
+                        obj.position.set(x, y, depth/2 + 0.05);
                         break;
                     case 1: // back
-                        obj.position.set(x, y, -depth/2 - 0.01);
+                        obj.position.set(x, y, -depth/2 - 0.05);
                         obj.rotation.y = Math.PI;
                         break;
                     case 2: // left
-                        obj.position.set(-width/2 - 0.01, y, x);
+                        obj.position.set(-width/2 - 0.05, y, x);
                         obj.rotation.y = -Math.PI/2;
                         break;
                     case 3: // right
-                        obj.position.set(width/2 + 0.01, y, x);
+                        obj.position.set(width/2 + 0.05, y, x);
                         obj.rotation.y = Math.PI/2;
                         break;
                 }


### PR DESCRIPTION
## Summary
- move windows slightly farther from building surface
- raise camera near plane for improved depth precision

## Testing
- `npm start` *(fails: command not found)*