### PR TITLE
Add more billboards and hide windows behind them

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@ import { EffectComposer } from "three/addons/postprocessing/EffectComposer.js";
 import { RenderPass } from "three/addons/postprocessing/RenderPass.js";
 import { UnrealBloomPass } from "three/addons/postprocessing/UnrealBloomPass.js";
 import { setupBasicLights } from "./src/environment.js";
-import { createSimpleBuilding, addOfficeWindows } from "./src/buildings.js";
+import { createSimpleBuilding, addOfficeWindows, WINDOW_GEO } from "./src/buildings.js";
 import { createSimpleCar } from "./src/cars.js";
 
 /* ---------- CONFIG ---------- */
@@ -190,7 +190,8 @@ function init(){
     createInitialZVehicles(); // Renamed
     createInitialXVehicles(); // Added
     createBillboards();
-    for(let i=0;i<3;i++){
+    // Increase the number of commercial billboards so video ads appear more frequently
+    for(let i=0;i<10;i++){
         const bb = createCommercialBillboard();
         billboards.push(bb);
     }
@@ -681,6 +682,24 @@ function placeBillboardOnBuilding(bb, building){
         case 2: bb.position.x = dims.w/2 + off; bb.rotation.y = Math.PI/2; break;
         case 3: bb.position.x = -dims.w/2 - off; bb.rotation.y = -Math.PI/2; break;
     }
+    // Remove windows that intersect the billboard so they do not appear behind it
+    const bbBox = new THREE.Box3().setFromObject(bb);
+    const tmpMatrix = new THREE.Matrix4();
+    const tmpPos = new THREE.Vector3();
+    building.traverse(child => {
+        if (child.isInstancedMesh && child.geometry === WINDOW_GEO) {
+            for (let i = 0; i < child.count; i++) {
+                child.getMatrixAt(i, tmpMatrix);
+                tmpPos.setFromMatrixPosition(tmpMatrix);
+                tmpPos.applyMatrix4(child.matrixWorld);
+                if (bbBox.containsPoint(tmpPos)) {
+                    tmpMatrix.setPosition(9999, 9999, 9999);
+                    child.setMatrixAt(i, tmpMatrix);
+                }
+            }
+            child.instanceMatrix.needsUpdate = true;
+        }
+    });
 }
 function createBillboard(){
     const w=Math.random()*18+12, h=Math.random()*10+6;


### PR DESCRIPTION
## Summary
- increase the number of commercial video billboards
- import `WINDOW_GEO` for billboard window removal
- hide windows directly behind new billboards so they don't show through

## Testing
- `git status --short`