### PR TITLE
Fix video playback initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,36 +126,49 @@ const commercialVideoFiles = [
 ];
 let currentCommercialIndex = Math.floor(Math.random() * commercialVideoFiles.length);
 commercialVideo.src = commercialVideoFiles[currentCommercialIndex];
-commercialVideo.loop = false;
+commercialVideo.loop = commercialVideoFiles.length === 1;
 commercialVideo.muted = true;
 commercialVideo.playsInline = true;
 commercialVideo.autoplay = true;
 commercialVideo.crossOrigin = 'anonymous';
-function playNextCommercialVideo(){
-    currentCommercialIndex = (currentCommercialIndex + 1) % commercialVideoFiles.length;
-    commercialVideo.src = commercialVideoFiles[currentCommercialIndex];
-    commercialVideo.load();
-    commercialTexture.needsUpdate = true;
-    commercialVideo.play().catch(err => {
-        console.warn('Commercial video failed to autoplay:', err);
-    });
-}
-commercialVideo.addEventListener('ended', playNextCommercialVideo);
-commercialVideo.load();
-commercialVideo.play().catch(err => {
-    console.warn('Commercial video failed to autoplay:', err);
-});
-let commercialAspectRatio = 2 / 3;
-commercialVideo.addEventListener('loadeddata', () => {
-    commercialAspectRatio = commercialVideo.videoWidth / commercialVideo.videoHeight;
-    init();
-});
+
 const commercialTexture = new THREE.VideoTexture(commercialVideo);
 commercialTexture.wrapS = THREE.ClampToEdgeWrapping;
 commercialTexture.wrapT = THREE.ClampToEdgeWrapping;
 commercialTexture.minFilter = THREE.LinearFilter;
 commercialTexture.magFilter = THREE.LinearFilter;
 commercialTexture.generateMipmaps = false;
+
+function playNextCommercialVideo(){
+    currentCommercialIndex = (currentCommercialIndex + 1) % commercialVideoFiles.length;
+    commercialVideo.src = commercialVideoFiles[currentCommercialIndex];
+    commercialVideo.load();
+    const onLoaded = () => {
+        commercialVideo.removeEventListener('loadeddata', onLoaded);
+        commercialTexture.needsUpdate = true;
+        commercialVideo.play().catch(err => {
+            console.warn('Commercial video failed to autoplay:', err);
+        });
+    };
+    commercialVideo.addEventListener('loadeddata', onLoaded);
+}
+
+if(commercialVideoFiles.length > 1){
+    commercialVideo.addEventListener('ended', playNextCommercialVideo);
+}
+
+let commercialAspectRatio = 2 / 3;
+function handleInitialVideoLoad(){
+    commercialVideo.removeEventListener('loadeddata', handleInitialVideoLoad);
+    commercialAspectRatio = commercialVideo.videoWidth / commercialVideo.videoHeight;
+    commercialTexture.needsUpdate = true;
+    commercialVideo.play().catch(err => {
+        console.warn('Commercial video failed to autoplay:', err);
+    });
+    init();
+}
+commercialVideo.addEventListener('loadeddata', handleInitialVideoLoad);
+commercialVideo.load();
 
 /* ---------- INIT ---------- */
 


### PR DESCRIPTION
## Summary
- wait for video to load before starting playback
- loop billboard video when only one clip is present
- reload commercial textures safely when switching videos

## Testing
- `npm test` *(fails: Missing script)*