### PR TITLE
Fix car rotation and lighting

### DIFF
--- a/index.html
+++ b/index.html
@@ -202,6 +202,16 @@ async function loadPlayerCar(){
         const loader = new GLTFLoader();
         const gltf = await loader.loadAsync(`./main_car/${file}`);
         playerCar = gltf.scene;
+        // GLB models may have arbitrary orientation. Rotate so the car faces -Z
+        playerCar.rotation.y = Math.PI / 2;
+
+        // Ensure the model is sufficiently lit and visible
+        playerCar.traverse(n => {
+            if(n.isMesh && n.material){
+                n.material.side = THREE.DoubleSide;
+            }
+        });
+
         playerCar.position.set(0,5,-50);
         scene.add(playerCar);
     }catch(err){

--- a/src/environment.js
+++ b/src/environment.js
@@ -1,8 +1,10 @@
 import * as THREE from 'three';
 
 export function setupBasicLights(scene) {
-    scene.add(new THREE.AmbientLight(0x505060, 1.0));
-    const dir = new THREE.DirectionalLight(0xffaa77, 0.5);
-    dir.position.set(0, -0.5, 0.5);
+    // Slightly brighter lighting to improve visibility of imported models
+    scene.add(new THREE.AmbientLight(0x505060, 1.5));
+
+    const dir = new THREE.DirectionalLight(0xffaa77, 1.0);
+    dir.position.set(5, 3, 5);
     scene.add(dir);
 }


### PR DESCRIPTION
## Summary
- increase ambient and directional light intensity
- rotate imported GLB car so it faces forward and ensure mesh is double-sided

## Testing
- `npm start` *(fails: serve not found)*