### PR TITLE
Fix player car loading on hosts without directory listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ page loads, one of these models will be chosen at random and followed from a
 third-person perspective. If the folder is empty or the files cannot be loaded,
 a simple placeholder car is used instead.
 
+Most static hosting services (such as GitHub Pages) do not expose a directory
+listing for `main_car/`. If `loadPlayerCar` cannot list the folder, specify the
+filenames manually in `CONFIG.PLAYER_CAR_FILES` inside `index.html`:
+
+```javascript
+CONFIG.PLAYER_CAR_FILES = ['stylish_black_car.glb'];
+```
+
+The files should still be placed in the `main_car` directory.
+
 If your model faces a different direction, adjust `CONFIG.PLAYER_CAR_ROTATION_Y`
 in `index.html`. The value is in radians and defaults to `Math.PI / 2` (90°).
 

--- a/index.html
+++ b/index.html
@@ -126,7 +126,8 @@ const CONFIG={
         ENABLE_FLICKER:true,
         NEON_SHUFFLE_INTERVAL:8
     },
-    PLAYER_CAR_ROTATION_Y: Math.PI / 2
+    PLAYER_CAR_ROTATION_Y: Math.PI / 2,
+    PLAYER_CAR_FILES: []
 };
 
 /* ---------- GLOBALS ---------- */
@@ -198,12 +199,20 @@ function initVideoTextures(){
 
 async function loadPlayerCar(){
     try{
-        const res = await fetch('./main_car/');
-        if(!res.ok) throw new Error('Directory not accessible');
-        const text = await res.text();
-        const matches = [...text.matchAll(/href="([^"?#]+\.(?:glb|ply))"/gi)].map(m=>m[1]);
-        if(matches.length === 0) throw new Error('No model files found');
-        const file = matches[Math.floor(Math.random()*matches.length)];
+        let files = Array.isArray(CONFIG.PLAYER_CAR_FILES) ? [...CONFIG.PLAYER_CAR_FILES] : [];
+
+        if(files.length === 0){
+            const res = await fetch('./main_car/');
+            if(res.ok){
+                const text = await res.text();
+                files = [...text.matchAll(/href="([^"?#]+\.(?:glb|ply))"/gi)].map(m=>m[1]);
+            }else{
+                console.warn('Directory listing not accessible:', res.statusText);
+            }
+        }
+
+        if(files.length === 0) throw new Error('No model files found');
+        const file = files[Math.floor(Math.random()*files.length)];
 
         if(file.toLowerCase().endsWith('.ply')){
             const loader = new PLYLoader();


### PR DESCRIPTION
## Summary
- support specifying filenames for the player car
- document how to host player car models on static services

## Testing
- `npm start` *(fails: serve not found)*