### PR TITLE
Disable player car

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ different filenames.
 
 ## Custom player car
 
+*Note: The current build disables the visible player car. The camera still
+follows an invisible placeholder object.*
+
 Add one or more `.glb` or `.ply` files to the `main_car` directory. When the
 page loads, one of these models will be chosen at random and followed from a
 third-person perspective. If the folder is empty or the files cannot be loaded,

--- a/index.html
+++ b/index.html
@@ -312,7 +312,11 @@ async function init(){
     scene.add(extraBuilding);
     buildings.push(extraBuilding);
 
-    await loadPlayerCar();
+    // Temporarily disable the visible player car. Instead create an invisible
+    // object for the camera to track so the rest of the animation logic works
+    // without modification.
+    playerCar = new THREE.Object3D();
+    playerCar.position.set(0, CONFIG.camera.BASE_HEIGHT, -50);
 
     window.addEventListener('resize',onResize);
     animate();


### PR DESCRIPTION
## Summary
- remove the visible player car and track an invisible object instead
- document that the player car is disabled

## Testing
- `npm start` *(fails: This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.)*